### PR TITLE
Include 'make' in DTS & A52 audio required packages

### DIFF
--- a/roles/hdmi-audio-dts-a52/tasks/main.yml
+++ b/roles/hdmi-audio-dts-a52/tasks/main.yml
@@ -13,6 +13,7 @@
       - libavformat-dev
       - libpulse-dev
       - git
+      - make
     state: latest
 
 - name: Clone alsa-plugins  repo


### PR DESCRIPTION
Make is required for compiling and (weirdly?) does not seem to be pulled as a transitive dependency of any other package, so the playbook/role fails on a fresh install. Just happened to me.